### PR TITLE
feat(route): add 吉首大学相关通知公告

### DIFF
--- a/lib/v2/jsu/jwc.js
+++ b/lib/v2/jsu/jwc.js
@@ -9,27 +9,25 @@ module.exports = async (ctx) => {
     const { types = 'jwtz' } = ctx.params;
     const selectors = {
         jwtz: {
-            list: 'body > div.w1180.isect1.clearfix > div.isect1_1 > div > div.textNews > table > tbody > tr',
-            title: 'td.titleborderstyle135034 > a',
             category: '教务通知',
+            url: 'https://jwc.jsu.edu.cn/tzgg.htm',
         },
         jwdt: {
-            list: 'body > div.w1180.isect1.clearfix > div.isect1_2 > table > tbody > tr',
-            title: 'td.titleborderstyle135032 > a',
             category: '教务动态',
+            url: 'https://jwc.jsu.edu.cn/jwdt.htm',
         },
     };
     const response = await got({
         method: 'get',
-        url: 'https://jwc.jsu.edu.cn/index.htm',
+        url: selectors[types].url,
     });
 
     const $ = cheerio.load(response.data);
-    const list = $(selectors[types].list).toArray();
+    const list = $('a.c135042').toArray();
     const out = await Promise.all(
         list.map((item) => {
             item = $(item);
-            const link = baseUrl + item.find(selectors[types].title).attr('href');
+            const link = new URL(item.attr('href'), baseUrl).href;
             return ctx.cache.tryGet(link, async () => {
                 const description = await getPageItemAndDate(
                     '#vsb_content',


### PR DESCRIPTION
* fea(route): add 吉首大学计算机科学与工程学院、吉首大学数统学院、吉首大学主站、创新中心通知公告、教务处教务动态、教务通知

* fix: 修复教务处返回的标题和描述为”计算机学院“

* style: 参照其他PR中Maintainer给出的建议，对radar.js 和 maintainer.js以字典序排序。

* refactor: 将整个RSS项对象作为缓存而不是单仅正文作为缓存，同时对应的修改了正文获取工具类中的内容，去除了固定的UserAgent；

<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
